### PR TITLE
Fix dependency conflict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 ic-agent = "0.31"
 ic-utils = "0.31"
-candid = "0.9"
+candid = "0.10"
 clap = { version = "4.4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1.0"


### PR DESCRIPTION
## Summary
- update `candid` crate to v0.10 to match `ic-agent`

## Testing
- `cargo build` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_685c84dfcf408321bce6c32ba31889d4